### PR TITLE
Don't reassign variables in keyboard::params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,15 +3,6 @@
 #
 
 class keyboard::params {
-
-    $model             = 'pc105'
-    $layout            = 'us'
-    $variant           = ''
-    $options           = ''
-    $backspace         = 'guess'
-    $package           = undef
-    $default_file      = undef
-
     case $::osfamily {
         'Debian': {
             $model             = 'pc105'


### PR DESCRIPTION
This fixes the following error in Puppet 3.7.2 when using this module: `Error: Cannot reassign variable model at /home/pkkm/conf/Puppet/lib/keyboard/manifests/params.pp:17`. I'm not sure if this is the right solution, but I made this pull request anyway since issues are disabled in this repository.
