### PR TITLE
Fix metadata.json to work on Puppet 3.7.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,7 @@
             ]
         }
     ],
+    "dependencies": [],
     "requirements": [
         {
             "name": "puppet",


### PR DESCRIPTION
This commit adds an empty `dependencies` entry. Without it, this module crashes on Puppet 3.7.2 with `Error: Puppet::Parser::AST::Resource failed with error ArgumentError: Could not find declared class keyboard`.